### PR TITLE
Update documents with the new host name.

### DIFF
--- a/script.js
+++ b/script.js
@@ -258,11 +258,7 @@ function parseRanks(data) {
 }
 
 function correctDocUrl(url) {
-  if (url.startsWith('https://oip-admin.nypdonline.local/')) {
-    return url.replace('https://oip-admin.nypdonline.local/', 'https://oip.nypdonline.org/')
-  } else {
-    return 'https://oip.nypdonline.org' + url
-  }
+  return 'https://nypdonline.org' + url
 }
 
 function parseDocuments(data) {


### PR DESCRIPTION
THe updated profile site uses nypdonline.org now instead of oip.nypdonline.org.

This also removes a special case for a bad document URL (added in https://github.com/ryanwatkins/nypd-officer-profiles/commit/87d2c5bb000c778cd6d94a45b1b2eabe94c01773) as it's not clear what this bad URL would look like with the new host name and it looks like the one document that was broken by this is now fixed.